### PR TITLE
delete displaying error message

### DIFF
--- a/Project03/ParseFile.java
+++ b/Project03/ParseFile.java
@@ -208,7 +208,7 @@ public class ParseFile {
 			dt = format.parse(date);
 		} catch (ParseException e) {
 			// TODO Auto-generated catch block
-			e.printStackTrace();
+			//e.printStackTrace();
 		}
 		return dt;
 	}


### PR DESCRIPTION
Because US42 require to have defect date format.
Date defect errors had already been handled.